### PR TITLE
Refactor play.c & Fix move bugs

### DIFF
--- a/srcs/play/play.c
+++ b/srcs/play/play.c
@@ -1,56 +1,87 @@
 #include "play.h"
 
-int	play(int key, t_info *info)
+static void	move_up_down(int key, t_map *map, t_player *player)
+{
+	int		x;
+	int		y;
+	double	x_offset;
+	double	y_offset;
+
+	x = (int)player->pos.x;
+	y = (int)player->pos.y;
+	x_offset = player->dir.x * MOVE_SPEED;
+	y_offset = player->dir.y * MOVE_SPEED;
+	if (key == KEY_W)
+	{
+		if (map->map[y][(int)(player->pos.x + x_offset)] != '1')
+			player->pos.x += x_offset;
+		if (map->map[(int)(player->pos.y + y_offset)][x] != '1')
+			player->pos.y += y_offset;
+	}
+	if (key == KEY_S)
+	{
+		if (map->map[y][(int)(player->pos.x - x_offset)] != '1')
+			player->pos.x -= x_offset;
+		if (map->map[(int)(player->pos.y - y_offset)][x] != '1')
+			player->pos.y -= y_offset;
+	}
+}
+
+static void	move_left_right(int key, t_map *map, t_player *player)
+{
+	int		x;
+	int		y;
+	double	x_offset;
+	double	y_offset;
+
+	x = (int)player->pos.x;
+	y = (int)player->pos.y;
+	x_offset = player->dir.x * MOVE_SPEED;
+	y_offset = player->dir.y * MOVE_SPEED;
+	if (key == KEY_A)
+	{
+		if (map->map[y][(int)(player->pos.x + y_offset)] != '1')
+			player->pos.x += y_offset;
+		if (map->map[(int)(player->pos.y + x_offset)][x] != '1')
+			player->pos.y += x_offset;
+	}
+	if (key == KEY_D)
+	{
+		if (map->map[y][(int)(player->pos.x - y_offset)] != '1')
+			player->pos.x -= y_offset;
+		if (map->map[(int)(player->pos.y - x_offset)][x] != '1')
+			player->pos.y -= x_offset;
+	}
+}
+
+static void	rotate(t_player *player, double sin_val, double cos_val)
 {
 	double	old_dir_x;
 	double	old_plane_x;
 
-	if (key == KEY_W)
-	{
-		if (info->map->map[(int)(info->player->pos.y)][(int)(info->player->pos.x + info->player->dir.x * MOVE_SPEED)] != '1')
-			info->player->pos.y += info->player->dir.y * MOVE_SPEED;
-		if (info->map->map[(int)(info->player->pos.y + info->player->dir.y * MOVE_SPEED)][(int)(info->player->pos.x)] != '1')
-			info->player->pos.x += info->player->dir.x * MOVE_SPEED;
-	}
-	if (key == KEY_S)
-	{
-		if (info->map->map[(int)(info->player->pos.y)][(int)(info->player->pos.x - info->player->dir.x * MOVE_SPEED)] != '1')
-			info->player->pos.y -= info->player->dir.y * MOVE_SPEED;
-		if (info->map->map[(int)(info->player->pos.y - info->player->dir.y * MOVE_SPEED)][(int)(info->player->pos.x)] != '1')
-			info->player->pos.x -= info->player->dir.x * MOVE_SPEED;
-	}
-	if (key == KEY_A)
-	{
-		if (info->map->map[(int)(info->player->pos.y)][(int)(info->player->pos.x + info->player->dir.y * MOVE_SPEED)] != '1')
-			info->player->pos.x += info->player->dir.y * MOVE_SPEED;
-		if (info->map->map[(int)(info->player->pos.y + info->player->dir.x * MOVE_SPEED)][(int)(info->player->pos.x)] != '1')
-			info->player->pos.y += info->player->dir.x * MOVE_SPEED;
-	}
-	if (key == KEY_D)
-	{
-		if (info->map->map[(int)(info->player->pos.y)][(int)(info->player->pos.x - info->player->dir.y * MOVE_SPEED)] != '1')
-			info->player->pos.x -= info->player->dir.y * MOVE_SPEED;
-		if (info->map->map[(int)(info->player->pos.y - info->player->dir.x * MOVE_SPEED)][(int)(info->player->pos.x)] != '1')
-			info->player->pos.y -= info->player->dir.x * MOVE_SPEED;
-	}
+	old_dir_x = player->dir.x;
+	player->dir.x = player->dir.x * cos_val - player->dir.y * sin_val;
+	player->dir.y = old_dir_x * sin_val + player->dir.y * cos_val;
+	old_plane_x = player->plane.x;
+	player->plane.x = player->plane.x * cos_val - player->plane.y * sin_val;
+	player->plane.y = old_plane_x * sin_val + player->plane.y * cos_val;
+}
+
+int	play(int key, t_info *info)
+{
+	t_map		*map;
+	t_player	*player;
+
+	map = info->map;
+	player = info->player;
+	if (key == KEY_W || key == KEY_S)
+		move_up_down(key, map, player);
+	if (key == KEY_A || key == KEY_D)
+		move_left_right(key, map, player);
 	if (key == KEY_LEFT)
-	{
-		old_dir_x = info->player->dir.x;
-		info->player->dir.x = info->player->dir.x * cos(-ROT_SPEED) - info->player->dir.y * sin(-ROT_SPEED);
-		info->player->dir.y = old_dir_x * sin(-ROT_SPEED) + info->player->dir.y * cos(-ROT_SPEED);
-		old_plane_x = info->player->plane.x;
-		info->player->plane.x = info->player->plane.x * cos(-ROT_SPEED) - info->player->plane.y * sin(-ROT_SPEED);
-		info->player->plane.y = old_plane_x * sin(-ROT_SPEED) + info->player->plane.y * cos(-ROT_SPEED);
-	}
+		rotate(player, sin(ROT_SPEED), cos(ROT_SPEED));
 	if (key == KEY_RIGHT)
-	{
-		old_dir_x = info->player->dir.x;
-		info->player->dir.x = info->player->dir.x * cos(ROT_SPEED) - info->player->dir.y * sin(ROT_SPEED);
-		info->player->dir.y = old_dir_x * sin(ROT_SPEED) + info->player->dir.y * cos(ROT_SPEED);
-		old_plane_x = info->player->plane.x;
-		info->player->plane.x = info->player->plane.x * cos(ROT_SPEED) - info->player->plane.y * sin(ROT_SPEED);
-		info->player->plane.y = old_plane_x * sin(ROT_SPEED) + info->player->plane.y * cos(ROT_SPEED);
-	}
+		rotate(player, sin(-ROT_SPEED), cos(-ROT_SPEED));
 	if (key == KEY_ESC)
 		exit(0);
 	return (0);


### PR DESCRIPTION
- play.c를 노미넷에 맞게 함수 분리 및 리팩토링
- `W` `S`로 상하 이동 시 코드가 잘못된 부분이 있어서 수정

❗️ rotate할 때 `ROT_SPEED`가 lodev와 반대로 되어 있어서 같도록 수정했습니다.
문제는 플레이어 방향이 `W` `S`일 때만 제대로 동작하고 `E` `N`일 때는 반대로 동작합니다.
(코드 수정 전에 제대로 동작하는 것처럼 보였던 이유도 `N`일 때만 테스트해봐서 그런 것 같습니다.)
이걸 어떻게 수정해야 할까요...