### PR TITLE
Fix map parsing error

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/05 17:54:55 by heehkim           #+#    #+#             */
-/*   Updated: 2022/08/05 18:12:01 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/08/07 17:44:48 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ static void	check_mapfile(t_map *map, char *line)
 		check_texture(map, line, line[0]);
 	else if (!ft_strncmp(line, "F ", 2) || !ft_strncmp(line, "C ", 2))
 		check_color(map, line);
-	else
+	else if (ft_strchr(" 01NSWE", line[0]))
 		check_valid_word(map, line);
 }
 
@@ -53,7 +53,6 @@ static void	read_mapfile(t_map *map, char *path)
 		free(line);
 		line = get_next_line(fd);
 	}
-	check_info(map);
 	if (!map->player)
 		exit_error("No player");
 	close(fd);

--- a/srcs/map/check_map.c
+++ b/srcs/map/check_map.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/05 17:55:27 by heehkim           #+#    #+#             */
-/*   Updated: 2022/08/05 18:20:19 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/08/07 17:43:37 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@ void	check_valid_word(t_map *map, char *line)
 	int	i;
 
 	i = 0;
+	check_info(map);
 	while (line[i] && (ft_isspace(line[i]) || line[i] == '0' || line[i] == '1' \
 		|| ft_strchr("NSWE", line[i])))
 	{


### PR DESCRIPTION
맵 파일의 플래그들(NO, SO, WE, EA, F, C)에 다른 문자가 섞여 있는 경우 맵으로 인식해서 적절하지 않은 오류 메시지를 출력하는 오류 수정