### PR TITLE
Refactor parsing map

### DIFF
--- a/srcs/init/init.c
+++ b/srcs/init/init.c
@@ -6,7 +6,7 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/05 17:55:09 by heehkim           #+#    #+#             */
-/*   Updated: 2022/08/08 19:27:29 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/08/09 23:32:24 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,23 +14,16 @@
 
 static void	init_map(t_map *map)
 {
-	map->has_info = FALSE;
-	map->width = 0;
-	map->height = 0;
 	map->floor = -1;
 	map->ceil = -1;
-	map->map = NULL;
 	map->tex_files = (char **)ft_calloc(4, sizeof(char *));
 	if (!map->tex_files)
 		exit_error("Failed to allocate memory");
-	map->start = 0;
-	map->end = 0;
-	map->player = 0;
 }
 
 void	init_info(t_info *info)
 {
-	info->map = (t_map *)malloc(sizeof(t_map));
+	info->map = (t_map *)ft_calloc(1, sizeof(t_map));
 	if (!info->map)
 		exit_error("Failed to allocate memory");
 	init_map(info->map);

--- a/srcs/map/check_map.c
+++ b/srcs/map/check_map.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   check_map.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hyunjcho <hyunjcho@student.42seoul.kr>     +#+  +:+       +#+        */
+/*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/05 17:55:27 by heehkim           #+#    #+#             */
-/*   Updated: 2022/08/07 18:40:17 by hyunjcho         ###   ########.fr       */
+/*   Updated: 2022/08/09 23:30:34 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,7 @@ void	check_valid_word(t_map *map, char *line)
 	int	i;
 
 	i = 0;
-	while (line[i] && (ft_isspace(line[i]) || line[i] == '0' || line[i] == '1' \
-		|| ft_strchr("NSWE", line[i])))
+	while (line[i] && ft_strchr(" 01NSWE", line[i]))
 	{
 		if (ft_strchr("NSWE", line[i]))
 		{

--- a/srcs/map/make_map.c
+++ b/srcs/map/make_map.c
@@ -6,19 +6,16 @@
 /*   By: heehkim <heehkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/05 17:55:46 by heehkim           #+#    #+#             */
-/*   Updated: 2022/08/05 18:16:28 by heehkim          ###   ########.fr       */
+/*   Updated: 2022/08/09 23:56:28 by heehkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "map.h"
 
-static void	set_player_pos(t_info *info, char c, int i, int j)
+static void	set_player_pos(t_info *info, int i, int j)
 {
-	if (c == info->map->start_dir)
-	{
-		info->player->pos.x = j + 0.5;
-		info->player->pos.y = i + 0.5;
-	}
+	info->player->pos.x = j + 0.5;
+	info->player->pos.y = i + 0.5;
 }
 
 static void	fill_map(t_info *info, char *line, int fd)
@@ -35,11 +32,9 @@ static void	fill_map(t_info *info, char *line, int fd)
 		j = 0;
 		while (line[j] && line[j] != '\n')
 		{
-			if (ft_isspace(line[j]))
-				info->map->map[i][j] = ' ';
-			else
-				info->map->map[i][j] = line[j];
-			set_player_pos(info, line[j], i, j);
+			info->map->map[i][j] = line[j];
+			if (line[j] == info->map->start_dir)
+				set_player_pos(info, i, j);
 			j++;
 		}
 		while (j < info->map->width - 1)


### PR DESCRIPTION
파싱 부분 코드를 다시 보다가 조금 정리해봤습니다~!
- 맵 안에 공백은 띄어쓰기(` `)만 허용하도록 통일했습니다.
  - 어차피 탭이나 다른 문자가 들어오면 cub 파일의 맵 모양 자체가 무너져서 제대로된 맵인지 아닌지 판단하기가 힘들고, 섭젝에도 구체적인 명시가 없기 때문에 그냥 딱 스페이스만 허용하는 걸로..!
- info의 map을 `ft_calloc`으로 할당해서 `init_map`의 요소를 0으로 초기화하는 필요없는 코드를 줄였습니다.

---
추가로 맵 테스터를 다시 돌려봤는데 이때가지 사용법을 잘 모르고 돌렸더라고요..ㅎㅎㅎ
제대로 다시 돌려봤더니 한 케이스가 제대로 통과를 못 하는데, 보니까 텍스쳐 파일이 중복으로 들어오는 케이스였어요.
```
NO ./textures/colorstone.xpm
NO ./textures/colorstone.xpm
SO ./textures/greystone.xpm
WE ./textures/redbrick.xpm
EA ./textures/wood.xpm
```
근데 이건 섭젝에 인포가 딱 하나씩만 들어와야 한다는 조건이 없기 때문에 디펜스가 충분히 가능할 것 같아서 굳이 수정은 하지 않았습니다!